### PR TITLE
add missing parens when using default widget

### DIFF
--- a/django_monaco_editor/fields.py
+++ b/django_monaco_editor/fields.py
@@ -7,4 +7,4 @@ class MonacoEditorField(forms.CharField):
     def __init__(self, *args, **kwargs):
         super(MonacoEditorField, self).__init__(*args, **kwargs)
         if not issubclass(self.widget.__class__, MonacoEditorWidget):
-            self.widget = MonacoEditorWidget
+            self.widget = MonacoEditorWidget()


### PR DESCRIPTION
Form field widget should be an instance rather than the class, for more info see https://stackoverflow.com/questions/42745403/use-required-attribute-missing-1-required-positional-argument-initial-djang